### PR TITLE
normalized keys in data recieved from alpha vantage for cleaner refer…

### DIFF
--- a/src/components/StockData.tsx
+++ b/src/components/StockData.tsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
-import { Stock } from '../types/Stock';
+import { NormalizedStock } from '../types/Stock';
 import "../css/StockResults.css";
 
 type StockDataProps = {
-  stockData: Stock[];
+  stockData: NormalizedStock[];
 };
 
 
@@ -12,12 +12,12 @@ const StockData: React.FC<StockDataProps> = ({ stockData }) => {
         <div className="stock-results">
             {stockData.map((stock) => (
                 <Link
-                    to={`/${stock['1. symbol']}`}
+                    to={`/${stock.symbol}`}
                     className="stock-result"
-                    key={stock['1. symbol']}
+                    key={stock.symbol}
                 >
                     <h3>
-                        {stock['2. name']} ({stock['1. symbol']})
+                        {stock.name} ({stock.symbol})
                     </h3>
                 </Link>
             ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { Stock } from '../types/Stock';
+import { NormalizedStock } from '../types/Stock';
 import StockData from '../components/StockData';
 import SearchBar from "../components/SearchBar";
 
 function Home() {
-    const [stockData, setStockData] = useState<Stock[]>([]);
+    const [stockData, setStockData] = useState<NormalizedStock[]>([]);
     
     return (
         <div className="home">

--- a/src/services/alpha_vantage_api.tsx
+++ b/src/services/alpha_vantage_api.tsx
@@ -1,4 +1,4 @@
-import { Stock } from '../types/Stock';
+import { NormalizedStock, normalizeStockList } from '../types/Stock';
 
 const API_KEY = import.meta.env.VITE_API_KEY;
 const BASE_URL = 'https://www.alphavantage.co/';
@@ -48,148 +48,15 @@ let cnq = [
         "7. timezone": "UTC-05",
         "8. currency": "CAD",
         "9. matchScore": "0.6667"
-    },
-    {
-        "1. symbol": "CNQ",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "1.0000"
-    },
-    {
-        "1. symbol": "CNQT",
-        "2. name": "Continental Capital Equities Inc",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.8571"
-    },
-    {
-        "1. symbol": "CNQQF",
-        "2. name": "Clean TeQ Water Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.7500"
-    },
-    {
-        "1. symbol": "CNQ.TRT",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "Toronto",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-05",
-        "8. currency": "CAD",
-        "9. matchScore": "0.6667"
-    },
-    {
-        "1. symbol": "CNQ",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "1.0000"
-    },
-    {
-        "1. symbol": "CNQT",
-        "2. name": "Continental Capital Equities Inc",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.8571"
-    },
-    {
-        "1. symbol": "CNQQF",
-        "2. name": "Clean TeQ Water Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.7500"
-    },
-    {
-        "1. symbol": "CNQ.TRT",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "Toronto",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-05",
-        "8. currency": "CAD",
-        "9. matchScore": "0.6667"
-    },
-    {
-        "1. symbol": "CNQ",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "1.0000"
-    },
-    {
-        "1. symbol": "CNQT",
-        "2. name": "Continental Capital Equities Inc",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.8571"
-    },
-    {
-        "1. symbol": "CNQQF",
-        "2. name": "Clean TeQ Water Ltd",
-        "3. type": "Equity",
-        "4. region": "United States",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-04",
-        "8. currency": "USD",
-        "9. matchScore": "0.7500"
-    },
-    {
-        "1. symbol": "CNQ.TRT",
-        "2. name": "Canadian Natural Resources Ltd",
-        "3. type": "Equity",
-        "4. region": "Toronto",
-        "5. marketOpen": "09:30",
-        "6. marketClose": "16:00",
-        "7. timezone": "UTC-05",
-        "8. currency": "CAD",
-        "9. matchScore": "0.6667"
     }
 ];
 
-export async function getStock(symbol: string): Promise<Stock[]> {
+export async function getStock(symbol: string): Promise<NormalizedStock[]> {
     let url: string = `${BASE_URL}/query?function=SYMBOL_SEARCH&keywords=${encodeURIComponent(symbol)}&apikey=${API_KEY}`;
     const response = await fetch(url);
     if (!response.ok) {
         throw new Error('API error: ${response.status');
     }
     const data = await response.json();
-    console.log(data);
-    return data['bestMatches'];
+    return normalizeStockList(data['bestMatches']);
 } 

--- a/src/types/Stock.ts
+++ b/src/types/Stock.ts
@@ -1,5 +1,5 @@
 
-export type StockKeys = [
+type StockKeys = [
   '1. symbol',
   '2. name',
   '3. type',
@@ -11,6 +11,37 @@ export type StockKeys = [
   '9. matchScore'
 ];
 
-export type Stock = {
+type Stock = {
   [K in StockKeys[number]]: string;
 };
+
+export type NormalizedStock = {
+  symbol: string;
+  name: string;
+  type: string;
+  region: string;
+  marketOpen: string;
+  marketClose: string;
+  timezone: string;
+  currency: string;
+  matchScore: string;
+};
+
+export function normalizeStock(stock: Stock): NormalizedStock {
+  return {
+    symbol: stock["1. symbol"],
+    name: stock["2. name"],
+    type: stock["3. type"],
+    region: stock["4. region"],
+    marketOpen: stock["5. marketOpen"],
+    marketClose: stock["6. marketClose"],
+    timezone: stock["7. timezone"],
+    currency: stock["8. currency"],
+    matchScore: stock["9. matchScore"]
+  };
+}
+
+export function normalizeStockList(stocks: Stock[]): NormalizedStock[] {
+  return stocks.map(normalizeStock);
+}
+


### PR DESCRIPTION
Alpha Vantage serves data with weird keys where each property is numbered (EG. '1. symbol', '2. name') which makes for awkward referencing of data from the JSON. Normalizing all data coming in from API requests allows for easier referencing and better readability.